### PR TITLE
fix wrong .h include

### DIFF
--- a/Teensy64/ili9341_t64.cpp
+++ b/Teensy64/ili9341_t64.cpp
@@ -33,7 +33,7 @@
 
 */
 
-#include "ILI9341_t64.h"
+#include "ili9341_t64.h"
 #include "vic_palette.h"
 
 #define SPICLOCK 144e6 //Just a number..max speed


### PR DESCRIPTION
Files are case sensitive, the file on disk was lowercase
so change the include directive in ili9341_t64.cpp